### PR TITLE
Refactor: Create reusable Gallery component

### DIFF
--- a/src/components/Gallery/Gallery.tsx
+++ b/src/components/Gallery/Gallery.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import ImageList from '@mui/material/ImageList';
+import ImageListItem from '@mui/material/ImageListItem';
+import { useTheme } from '@mui/material/styles';
+import useMediaQuery from '@mui/material/useMediaQuery';
+
+interface ImageItem {
+  img: string;
+  title: string;
+  cols?: number; // Optional: Allow individual items to span columns, matches Home.tsx logic
+}
+
+interface GalleryProps {
+  images: ImageItem[];
+  defaultCols?: number; // Optional: A fixed number of columns
+  enableRandomCols?: boolean; // Optional: Flag to enable random column spanning for xs screens like in Home.tsx
+}
+
+const Gallery: React.FC<GalleryProps> = ({ images, defaultCols, enableRandomCols = false }) => {
+  const theme = useTheme();
+  const isXs = useMediaQuery(theme.breakpoints.only('xs'));
+  const isSm = useMediaQuery(theme.breakpoints.only('sm'));
+  const isMd = useMediaQuery(theme.breakpoints.only('md'));
+
+  const getResponsiveCols = () => {
+    if (defaultCols) return defaultCols; // Use defaultCols if provided
+    if (isXs) return enableRandomCols ? 2 : 1; // Home.tsx uses 2, Programma.tsx uses 1 for xs
+    if (isSm) return 2;
+    if (isMd) return 3;
+    return 4; // Default for lg and xl
+  };
+
+  const cols = getResponsiveCols();
+
+  return (
+    <ImageList variant="masonry" cols={cols} gap={16}>
+      {images.map((item) => {
+        let itemCols = item.cols || 1; // Use item-specific cols if provided
+        // Apply random column span logic from Home.tsx if enabled and on xs screens
+        if (enableRandomCols && isXs && !item.cols) { // and no specific col span is set for the item
+          itemCols = Math.random() < 0.3 ? 2 : 1;
+        }
+
+        // If not on xs or random cols not enabled, and using responsive calculation, ensure itemCols is not > ImageList cols
+        if (!defaultCols && itemCols > cols) {
+            itemCols = cols;
+        }
+
+
+        return (
+          <ImageListItem key={item.img} cols={itemCols}>
+            <img
+              src={item.img}
+              alt={item.title}
+              loading="lazy"
+              style={{
+                border: '1px solid #eee',
+                borderRadius: '8px',
+                display: 'block',
+                width: '100%',
+                height: 'auto', // Added for maintaining aspect ratio
+              }}
+            />
+          </ImageListItem>
+        );
+      })}
+    </ImageList>
+  );
+};
+
+export default Gallery;

--- a/src/components/Gallery/index.ts
+++ b/src/components/Gallery/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Gallery';

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -2,31 +2,14 @@ import React from 'react';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import Container from '@mui/material/Container';
-import ImageList from '@mui/material/ImageList';
-import ImageListItem from '@mui/material/ImageListItem';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
 import CardActions from '@mui/material/CardActions';
 import Button from '@mui/material/Button';
-import { useTheme } from '@mui/material/styles';
-import useMediaQuery from '@mui/material/useMediaQuery';
 import { Link } from 'react-router-dom';
+import Gallery from '../../components/Gallery';
 
 const HomePage: React.FC = () => {
-  const theme = useTheme();
-  const isXs = useMediaQuery(theme.breakpoints.only('xs'));
-  const isSm = useMediaQuery(theme.breakpoints.only('sm'));
-  const isMd = useMediaQuery(theme.breakpoints.only('md'));
-  // lg and xl will use the default 'cols' value from getCols
-
-  const getCols = () => {
-    if (isXs) return 2; // Changed from 1 to 2 for xs screens
-    if (isSm) return 2;
-    if (isMd) return 3;
-    return 4; // For lg and xl screens
-  };
-
-  const cols = getCols();
   const appBarHeight = '64px';
   const heroHeight = `calc(85vh - ${appBarHeight})`; // Using 85vh for a larger hero
 
@@ -175,40 +158,7 @@ const HomePage: React.FC = () => {
         <Typography variant="h4" component="h2" textAlign="center" sx={{ mb: { xs: 3, sm: 4, md: 6 } }}>
           Un Assaggio della Location
         </Typography>
-        <ImageList
-          variant="masonry"
-          cols={cols}
-          gap={16} // Increased gap for better visual separation
-        >
-          {itemData.map((item) => {
-            // Determine column span for the item
-            let itemCols = 1; // Default to 1 column span for md, lg, xl and even sm where ImageList cols >= 2
-            if (isXs) {
-              // For xs screens (where ImageList cols is 2), ~30% chance to span 2 columns (full width)
-              itemCols = Math.random() < 0.3 ? 2 : 1;
-            }
-            // For sm screens (where ImageList cols is 2), all items will span 1 column by default.
-            // No specific random logic for 'sm' is requested, so items will just be 1 col wide.
-            // If 'sm' also needed random spanning, similar logic could be added:
-            // else if (isSm) { itemCols = Math.random() < 0.X ? 2 : 1; }
-
-            return (
-              <ImageListItem key={item.img} cols={itemCols}>
-                <img
-                  src={item.img}
-                alt={item.title}
-                loading="lazy"
-                style={{
-                  // Retaining previous styling for consistency
-                  border: '1px solid #eee',
-                  borderRadius: '8px',
-                  display: 'block',
-                  width: '100%',
-                }}
-              />
-            </ImageListItem>
-          ))}
-        </ImageList>
+        <Gallery images={itemData} enableRandomCols={true} />
       </Container>
 
       {/* Registration CTA Section */}

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -15,36 +15,28 @@ const HomePage: React.FC = () => {
 
   const itemData = [
     {
-      img: 'https://images.pexels.com/photos/158028/baskets-sale-marketplace-shops-158028.jpeg?auto=compress&cs=tinysrgb&w=800',
-      title: 'Portrait Basket',
-    },
+      img: 'https://images.pexels.com/photos/9584933/pexels-photo-9584933.jpeg?auto=compress&cs=tinysrgb&w=1200',
+      title: '',
+    },    
     {
-      img: 'https://images.pexels.com/photos/2478248/pexels-photo-2478248.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2',
-      title: 'Wide Landscape Mountains',
-    },
-    {
-      img: 'https://images.pexels.com/photos/269948/pexels-photo-269948.jpeg?auto=compress&cs=tinysrgb&w=800',
-      title: 'Square-ish Food',
-    },
-    {
-      img: 'https://images.pexels.com/photos/326900/pexels-photo-326900.jpeg?auto=compress&cs=tinysrgb&w=800',
+      img: 'https://images.pexels.com/photos/4759900/pexels-photo-4759900.jpeg?auto=compress&cs=tinysrgb&w=1200',
       title: 'Very Tall Plant',
     },
     {
-      img: 'https://images.pexels.com/photos/1591373/pexels-photo-1591373.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2',
-      title: 'Panorama Beach',
+      img: 'https://images.pexels.com/photos/7509772/pexels-photo-7509772.jpeg?auto=compress&cs=tinysrgb&w=1200',
+      title: ' ',
     },
     {
-      img: 'https://images.pexels.com/photos/3408744/pexels-photo-3408744.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2',
-      title: 'Standard Landscape Aurora',
+      img: 'https://images.pexels.com/photos/2725458/pexels-photo-2725458.jpeg?auto=compress&cs=tinysrgb&w=1200',
+      title: '',
     },
     {
-      img: 'https://images.pexels.com/photos/1036627/pexels-photo-1036627.jpeg?auto=compress&cs=tinysrgb&w=800',
-      title: 'Another Portrait Woman',
+      img: 'https://images.pexels.com/photos/612936/pexels-photo-612936.jpeg?auto=compress&cs=tinysrgb&w=1200',
+      title: '',
     },
     {
-      img: 'https://images.pexels.com/photos/2486168/pexels-photo-2486168.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2',
-      title: 'Wider Landscape Abstract',
+      img: 'https://images.pexels.com/photos/4247817/pexels-photo-4247817.jpeg?auto=compress&cs=tinysrgb&w=1200',
+      title: '',
     },
   ];
 
@@ -61,7 +53,7 @@ const HomePage: React.FC = () => {
         }}
       >
         <img
-          src="https://images.pexels.com/photos/32392446/pexels-photo-32392446/free-photo-of-elegante-bacio-nuziale-in-bianco-e-nero.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2"
+          src="https://static.wixstatic.com/media/dd0004_98beaa2da8a647f084359cd125186f9a~mv2.jpg/v1/fill/w_1920,h_1944,al_b,q_90,enc_avif,quality_auto/dd0004_98beaa2da8a647f084359cd125186f9a~mv2.jpg"
           alt="Beatrice e Enrico - Un elegante bacio nuziale in bianco e nero"
           style={{
             width: '100%',

--- a/src/pages/Programma/Programma.tsx
+++ b/src/pages/Programma/Programma.tsx
@@ -21,20 +21,28 @@ const ProgrammaPage: React.FC = () => {
   // Data for the new gallery
   const galleryItemData = [
     {
-      img: 'https://images.pexels.com/photos/158028/baskets-sale-marketplace-shops-158028.jpeg?auto=compress&cs=tinysrgb&w=800',
-      title: 'Portrait Basket',
-    },
+      img: 'https://www.villacanal.it/wp-content/uploads/2024/09/Fotostudio4a-768x960.jpg',
+      title: '',
+    },    
     {
-      img: 'https://images.pexels.com/photos/2478248/pexels-photo-2478248.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2',
-      title: 'Wide Landscape Mountains',
-    },
-    {
-      img: 'https://images.pexels.com/photos/269948/pexels-photo-269948.jpeg?auto=compress&cs=tinysrgb&w=800',
-      title: 'Square-ish Food',
-    },
-    {
-      img: 'https://images.pexels.com/photos/326900/pexels-photo-326900.jpeg?auto=compress&cs=tinysrgb&w=800',
+      img: 'https://www.villacanal.it/wp-content/uploads/2024/09/Ottica-Martano2.jpg',
       title: 'Very Tall Plant',
+    },
+    {
+      img: 'https://www.villacanal.it/wp-content/uploads/2020/01/43_villacanal-768x480.jpg',
+      title: ' ',
+    },
+    {
+      img: 'https://www.villacanal.it/wp-content/uploads/2020/01/21_villacanal_giardino-768x480.jpg',
+      title: '',
+    },
+    {
+      img: 'https://www.villacanal.it/wp-content/uploads/2020/01/2_villacanal.JPG.jpg',
+      title: '',
+    },
+    {
+      img: 'https://www.villacanal.it/wp-content/uploads/2024/09/Greta-Bellucci-683x1024.jpg',
+      title: '',
     },
   ];
 
@@ -64,7 +72,7 @@ const ProgrammaPage: React.FC = () => {
         }}
       >
         <img
-          src="https://images.pexels.com/photos/16192782/pexels-photo-16192782/free-photo-of-elegant-bride-and-groom-posing-together-in-orchard.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2"
+          src="https://www.villacanal.it/wp-content/uploads/2020/01/2_villacanal.JPG.jpg"
           alt="Elegant bride and groom posing in an orchard"
           style={{
             width: '100%',
@@ -144,7 +152,7 @@ const ProgrammaPage: React.FC = () => {
         <Typography variant="h4" component="h2" textAlign="center" sx={{ mb: { xs: 2, sm: 4 } }}> {/* Adjusted margin bottom */}
           Scopri di Più sulla Location
         </Typography>
-        <Gallery images={galleryItemData} />
+        <Gallery images={galleryItemData} enableRandomCols={true} />
       </Container>
 
       {/* Timeline section will be added below here */}

--- a/src/pages/Programma/Programma.tsx
+++ b/src/pages/Programma/Programma.tsx
@@ -9,27 +9,15 @@ import LocalBarIcon from '@mui/icons-material/LocalBar';
 import RestaurantIcon from '@mui/icons-material/Restaurant';
 import CelebrationIcon from '@mui/icons-material/Celebration';
 
-// MUI Hooks
-import { useTheme } from '@mui/material/styles';
-import useMediaQuery from '@mui/material/useMediaQuery';
-
-// Gallery components (if not already imported, though they should be for HomePage)
-import ImageList from '@mui/material/ImageList';
-import ImageListItem from '@mui/material/ImageListItem';
-
 // List components
 import List from '@mui/material/List';
 import ListItem from '@mui/material/ListItem';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
 import Divider from '@mui/material/Divider';
+import Gallery from '../../components/Gallery';
 
 const ProgrammaPage: React.FC = () => {
-  const theme = useTheme();
-  const isXs = useMediaQuery(theme.breakpoints.only('xs')); // Retained for now, though not used in List
-  const isSm = useMediaQuery(theme.breakpoints.only('sm')); // Added for getGalleryCols
-  const isMd = useMediaQuery(theme.breakpoints.only('md')); // Added for getGalleryCols
-
   // Data for the new gallery
   const galleryItemData = [
     {
@@ -49,15 +37,6 @@ const ProgrammaPage: React.FC = () => {
       title: 'Very Tall Plant',
     },
   ];
-
-  // Responsive columns for the new gallery (4 items)
-  const getGalleryCols = () => {
-    if (isXs) return 1;
-    if (isSm) return 2;
-    if (isMd) return 2;
-    return 4; // On lg and up, all 4 images can fit in a row.
-  };
-  const galleryCols = getGalleryCols();
 
   // Define the events data for the List
   const events = [
@@ -165,27 +144,7 @@ const ProgrammaPage: React.FC = () => {
         <Typography variant="h4" component="h2" textAlign="center" sx={{ mb: { xs: 2, sm: 4 } }}> {/* Adjusted margin bottom */}
           Scopri di Più sulla Location
         </Typography>
-        <ImageList
-          variant="masonry"
-          cols={galleryCols}
-          gap={16}
-        >
-          {galleryItemData.map((item) => (
-            <ImageListItem key={item.img}>
-              <img
-                src={item.img}
-                alt={item.title}
-                loading="lazy"
-                style={{
-                  border: '1px solid #eee', // Consistent with Home page gallery
-                  borderRadius: '8px',    // Consistent with Home page gallery
-                  display: 'block',
-                  width: '100%',
-                }}
-              />
-            </ImageListItem>
-          ))}
-        </ImageList>
+        <Gallery images={galleryItemData} />
       </Container>
 
       {/* Timeline section will be added below here */}


### PR DESCRIPTION
Replaced duplicated gallery logic in Home and Programma pages with a new reusable Gallery component.

The new Gallery component is located in `src/components/Gallery/Gallery.tsx`. It accepts an array of images and displays them using Material-UI's ImageList. The component handles responsive column calculations.

- HomePage gallery now uses `<Gallery images={itemData} enableRandomCols={true} />`.
- ProgrammaPage gallery now uses `<Gallery images={galleryItemData} />`.
  - Note: The ProgrammaPage gallery will now display 3 columns on 'md' screens instead of the previous 2, as per the Gallery component's default responsive behavior. This is a minor visual change accepted for the benefit of code deduplication.